### PR TITLE
Fix build on Arch Linux: signal handler and autogen improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-06-07  Artur Ladka  <arturladka@gmail.com>
+
+	* Added proper signal handling for application termination
+	* Improved build system scripts (libtool, autotools) and documentation.
+
 2025-05-23  Artur Ladka  <arturladka@gmail.com>
 
 	* Modernized codebase to support recent GCC and GLib versions

--- a/README.md
+++ b/README.md
@@ -30,23 +30,35 @@ sudo apt install utimer
 ### Build from Source
 
 Requirements:
-- `glib-2.0`
-- `autotools`
+- `glib-2.0` (with `gobject` and `gthread`)
+- `gio-unix-2.0`
+- `autoconf`
+- `automake`
+- `libtool`
 - `intltool`
+- `gettext`
 
-To compile:
-
+#### For Ubuntu/Debian:
 ```bash
-./configure
-make
-sudo make install
+sudo apt install build-essential autoconf automake libtool intltool libglib2.0-dev gettext
 ```
 
-If `./configure` fails, try:
-
+#### For Arch Linux:
 ```bash
+sudo pacman -S base-devel autoconf automake libtool intltool gettext glib2
+```
+
+#### Build instructions:
+```bash
+# Generate the build system
 ./autogen.sh
-./configure && make
+
+# Configure and build
+./configure
+make
+
+# Install
+sudo make install
 ```
 
 To run tests:

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,15 +1,29 @@
-   echo "========= Preparing uTimer ============"\
-&& echo "======== Running autoreconf ==========="\
-&& autoreconf --force --install --verbose \
-&& echo "======== Running glib-gettextize ======"\
-&& glib-gettextize --force --copy \
-&& echo "======== Running intltoolize =========="\
-&& echo "(there may be no output, it's fine)"\
-&& intltoolize --copy --force --automake \
-&& echo "=============== DONE ==================" \
-&& echo -e "You can now type these commands: \n$ ./configure\n$ make\n$ make install\nAnd then uTimer should be installed!" \
-&& echo "=============== EOF ==================="
+#!/bin/sh
+echo "========= Preparing uTimer ============"
+# Add libtoolize first
+echo "======== Running libtoolize ==========="
+libtoolize --force --copy || exit 1
+
+echo "======== Running autoreconf ==========="
+autoreconf --force --install --verbose -I/usr/share/gettext/m4 -I/usr/share/aclocal || exit 1
+
+echo "======== Running glib-gettextize ======"
+glib-gettextize --force --copy || exit 1
+
+echo "======== Running intltoolize =========="
+echo "(there may be no output, it's fine)"
+intltoolize --copy --force --automake || exit 1
+
+echo "=============== DONE ================="
+echo "You can now type these commands:"
+echo "$ ./configure"
+echo "$ make"
+echo "$ sudo make install"
+echo "And then uTimer should be installed!"
+echo "=============== EOF ================="
+
 if [ ! -f ChangeLog ]; then
-  echo -e "Creating empty ChangeLog...\nIMPORTANT: ChangeLog is only generated for dist packages (.tar.gz) from the bzr log."
+  echo "Creating empty ChangeLog..."
+  echo "IMPORTANT: ChangeLog is only generated for dist packages (.tar.gz) from the bzr log."
   touch ChangeLog
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,12 @@
 AC_INIT([utimer], [0.4], [bugs@utimer.codealpha.net])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+
+# Create m4 directory for macros
+AC_CONFIG_MACRO_DIR([m4])
+
+# Add libtool support
+LT_INIT
+
 AC_PROG_CC
 AC_CONFIG_HEADERS([config.h])
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -198,6 +198,18 @@ void error_quitloop ()
 }
 
 /**
+ * Quits the main loop with error to end the program.
+ * Quits the main loop to end the program ungracefully (EXIT_FAILURE).
+ * This function is called when a signal is received.
+ * It just calls error_quitloop().
+ */
+void error_quitloop_signal (int signal)
+{
+  (void)signal;  // suppress unused warning
+  error_quitloop();
+}
+
+/**
  * Quits the main loop with success code to end the program.
  * Quits the main loop to end the program gracefully (EXIT_SUCCESS).
  * This function just calls quitloop(EXIT_SUCCESS).

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,6 +46,7 @@ gboolean      start_thread_exit_check   (ut_timer *timer);
 int           check_exit_from_user      ();
 void          quitloop                  (int error_status);
 void          error_quitloop            ();
+void          error_quitloop_signal     (int signal);
 void          success_quitloop          ();
 void          set_tty_canonical         (int state);
 void          reset_tty_canonical_mode  ();

--- a/src/utimer.c
+++ b/src/utimer.c
@@ -206,12 +206,12 @@ int main (int argc, char *argv[])
    * we need to stop the main loop to exit correctly, but
    * with error code!
    */
-  signal (SIGALRM,  error_quitloop);
-  signal (SIGHUP,   error_quitloop);
-  signal (SIGINT,   error_quitloop);
-  signal (SIGPIPE,  error_quitloop);
-  signal (SIGQUIT,  error_quitloop);
-  signal (SIGTERM,  error_quitloop);
+  signal (SIGALRM,  error_quitloop_signal);
+  signal (SIGHUP,   error_quitloop_signal);
+  signal (SIGINT,   error_quitloop_signal);
+  signal (SIGPIPE,  error_quitloop_signal);
+  signal (SIGQUIT,  error_quitloop_signal);
+  signal (SIGTERM,  error_quitloop_signal);
   
   /* Set up the log handler */
   setup_log_handler ();


### PR DESCRIPTION
This PR addresses build failures on Arch Linux by fixing both the signal handler and the autogen script.

### 🔧 Fixes:
- Added `error_quitloop_signal(int)` wrapper for POSIX-compliant `signal()` usage
  - Original `error_quitloop()` (void) is preserved for internal use
- Updated `autogen.sh` to include:
  - `libtoolize`
  - `-I /usr/share/gettext/m4` to find gettext macros
- Improved README with Arch-specific build and dependency instructions

### 🧪 Testing
Tested successfully using:
```bash
docker run -it --rm -v ~/dev/arch/utimer:/src archlinux:latest
pacman -Syu --noconfirm && pacman -S --noconfirm base-devel autoconf automake libtool intltool gettext glib2
cd /src
./autogen.sh
./configure
make