### PR TITLE
Add GitHub Actions CI with amd64 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build and Test
+
+on:
+  push:
+    # Build all branches
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          autotools-dev \
+          automake \
+          autoconf \
+          libtool \
+          intltool \
+          gettext \
+          gettext-base \
+          autopoint \
+          libglib2.0-dev \
+          pkg-config \
+          bash-completion
+
+    - name: Generate build system
+      run: ./autogen.sh
+
+    - name: Configure
+      run: ./configure
+
+    - name: Build
+      run: make
+
+    - name: Test installation
+      run: |
+        sudo make install
+        which utimer
+        utimer --help


### PR DESCRIPTION
## Overview
Adds initial GitHub Actions CI workflow for automated building and testing on amd64 architecture.

## Changes
- **Build automation**: Full autotools build pipeline (autogen → configure → make)
- **Dependency management**: All required packages including autopoint for gettext
- **Installation verification**: Tests that binary installs and executes correctly
- **Ubuntu latest**: Reliable CI environment for consistent builds

## Testing
- ✅ Build system generation
- ✅ Compilation 
- ✅ Installation
- ✅ Basic functionality (`utimer --help`)

Ready for automated CI on all branches and PRs.