### PR TITLE
Initialize timer_print_source_id to resolve test failures and re-enable test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Build
       run: make
 
+    - name: Run tests
+      run: make check
+
     - name: Test installation
       run: |
         sudo make install

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -3,23 +3,16 @@ include $(top_srcdir)/Makefile.decl
 AM_CPPFLAGS = $(GLIB_CFLAGS) $(UT_DEBUG_FLAGS)
 
 # ==  Tests  ==
-#
-# WARNING: Tests are currently disabled due to a GLib timer source removal bug:
-# "Source ID 540028980 was not found when attempting to remove it"
-# This is a code issue in maintests.c, not a build system problem.
-# TODO: Fix the timer cleanup logic in the test code.
-#
-# To re-enable tests, uncomment the lines below and add maintests to TEST_PROGS:
 
 progs_ldadd = $(GLIB_LIBS) $(GIO_LIBS)
-# TEST_PROGS          += maintests
-# maintests_SOURCES    = maintests.c \
-#                        $(top_srcdir)/src/utimer.h \
-#                        $(top_srcdir)/src/timer.c  $(top_srcdir)/src/timer.h \
-#                        $(top_srcdir)/src/utils.h  $(top_srcdir)/src/utils.c \
-#                        $(top_srcdir)/src/log.c    $(top_srcdir)/src/log.h
-#
-# maintests_LDADD     = $(progs_ldadd)
+TEST_PROGS          += maintests
+maintests_SOURCES    = maintests.c \
+                       $(top_srcdir)/src/utimer.h \
+                       $(top_srcdir)/src/timer.c  $(top_srcdir)/src/timer.h \
+                       $(top_srcdir)/src/utils.h  $(top_srcdir)/src/utils.c \
+                       $(top_srcdir)/src/log.c    $(top_srcdir)/src/log.h
+
+maintests_LDADD     = $(progs_ldadd)
 
 # == End Tests ==
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -365,6 +365,7 @@ ut_timer* timer_new (guint seconds,
   t->mseconds = mseconds;
   t->mode = mode;
   t->checkloop_thread_stop_with_error = FALSE;
+  t->timer_print_source_id = 0; // Initialize to 0 (invalid source ID)
   t->success_callback = success_callback;
   t->error_callback   = error_callback;
   t->gtimer      = timer;


### PR DESCRIPTION
# Pull Request: Fix test failures and re-enable test suite

## Title
```
fix: Initialize timer_print_source_id to resolve test failures and re-enable test suite
```

## Description

### 🐛 Problem
Tests were disabled due to a critical GLib error:
```
Source ID 540028980 was not found when attempting to remove it
```
This caused the `/Timer/Duration/Test1` test to crash with `Trace/breakpoint trap (core dumped)`, leading to the entire test suite being disabled in both the build system and CI pipeline.

### 🔍 Root Cause Analysis
The issue was an **uninitialized memory bug** in `src/timer.c`:
- The `timer_print_source_id` field in `ut_timer` struct was never initialized in `timer_new()`
- It contained random garbage data (e.g., `540028980`)
- When `g_source_remove(t->timer_print_source_id)` was called in the timer cleanup, it attempted to remove a non-existent GLib source
- GLib correctly threw a critical error for the invalid source ID

### ✅ Solution
1. **Core Fix**: Initialize `timer_print_source_id = 0` in `timer_new()` function
   - Since 0 is not a valid GLib source ID, the conditional `if (t->timer_print_source_id)` becomes false
   - This prevents the invalid `g_source_remove()` call

2. **Test Re-enablement**: Remove outdated warning comments and re-enable tests in `src/tests/Makefile.am`

3. **CI Integration**: Add `make check` step to GitHub Actions workflow for continuous testing

### 🧪 Testing
- ✅ All 5 tests now pass consistently: 
  - `/Utils/Suffix/Test1: OK`
  - `/Timer/Duration/Test1: OK` ← Previously failing
  - `/General/TimerCreation/Timer: OK`
  - `/General/TimerCreation/Stopwatch: OK`  
  - `/General/TimerCreation/Countdown: OK`
- ✅ `make check` verified to work properly
- ✅ Tests run multiple times in different directories (all pass)

### 📋 Changes
- `src/timer.c`: Add `t->timer_print_source_id = 0;` initialization (1 line)
- `src/tests/Makefile.am`: Re-enable tests and clean up outdated warnings
- `.github/workflows/build.yml`: Add `make check` to CI pipeline

### 🎯 Impact  
- **Low Risk**: Minimal change (single line initialization)
- **High Value**: Re-enables automated testing for quality assurance
- **Industry Standard**: Proper initialization prevents undefined behavior
- **CI/CD Ready**: Tests now run automatically on every push/PR

### 📝 Notes
- Tests use deprecated `gtester` framework (GLib 2.62+ warning) but are fully functional
- Fix is based on latest `master` with minimal source approach
- Ready for immediate merge
